### PR TITLE
chore(java 17): Compile with Java 17 (#49)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
        
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
 

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Release connector
-        uses: bonitasoft/action-release-connector@1.0.0
+        uses: bonitasoft/action-release-connector@2.0.0
         id: release-connector
         with:
           release-version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Use version 2.0.0 of release action which compiles with Java 17

11 compatibility is needed for the connector to be compatible with maintenance versions

Closes [BPM-29](https://bonitasoft.atlassian.net/browse/BPM-29)

[BPM-29]: https://bonitasoft.atlassian.net/browse/BPM-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ