### PR TITLE
chore(ci): add optional marketplace notification to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: 'The version of the release. Used as tag name.'
         required: true
         default: 'x.y.z'
+      update_marketplace:
+        description: 'Update marketplace after release'
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -16,3 +20,21 @@ jobs:
     with:
       release-version: ${{ github.event.inputs.version }}
     secrets: inherit
+
+  notify-marketplace:
+    needs: release
+    if: ${{ inputs.update_marketplace }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Notify marketplace
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
+          repository: bonitasoft/bonita-marketplace
+          event-type: new-connector-release
+          client-payload: >-
+            {
+              "artifactId": "bonita-connector-salesforce",
+              "version": "${{ inputs.version }}",
+              "bonitaMinVersion": "7.13.0"
+            }


### PR DESCRIPTION
## Summary
- Adds an opt-in `update_marketplace` boolean input to the release workflow (default: `false`)
- When enabled, dispatches a `new-connector-release` event to `bonitasoft/bonita-marketplace`
- Intermediate/internal releases can skip marketplace update by leaving the default

## How it works
During a release, set `update_marketplace: true` to automatically notify the marketplace repo with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)